### PR TITLE
Updated plugin.yml for Multiverse support

### DIFF
--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -2,6 +2,7 @@ name: EliteMobs
 version: 2.3.2
 author: MagmaGuy
 main: com.magmaguy.elitemobs.EliteMobs
+softdepend: [Multiverse-Core]
 commands:
   elitemobs:
     description: Tells a player the statistics of the


### PR DESCRIPTION
EliteMobs has a tendency to load before Multiverse-Core meaning that it is unable to find any Multiverse worlds. Adding Multiverse-Core as a softdepend ensures that it will load first and that EliteMobs will be able to spawn elite mobs in Multiverse worlds when in the config.yml.