### PR TITLE
Added config option to disable hide_enchants

### DIFF
--- a/src/main/java/com/magmaguy/elitemobs/config/ItemSettingsConfig.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/ItemSettingsConfig.java
@@ -113,6 +113,8 @@ public class ItemSettingsConfig extends ConfigurationFile {
     @Getter
     private static boolean hideAttributes;
     @Getter
+    private static boolean hideEnchants;
+    @Getter
     private static String weaponEntry;
     @Getter
     private static String armorEntry;
@@ -351,6 +353,9 @@ public class ItemSettingsConfig extends ConfigurationFile {
         hideAttributes = ConfigurationEngine.setBoolean(
                 List.of("Sets if EliteMobs will hide vanilla Minecraft attributes."),
                 fileConfiguration, "hideItemAttributes", true);
+        hideEnchants = ConfigurationEngine.setBoolean(
+                List.of("Sets if EliteMobs will hide enchantment tooltips on EliteMobs items."),
+                fileConfiguration, "hideEnchants", true);
         weaponEntry = ConfigurationEngine.setString(
                 List.of("Sets the weapon-specific lore entry on an elite item. The $EDPS placeholder gets replaced with the elite DPS (damage per second) of the weapon."),
                 file, fileConfiguration, "weaponEntry", "&7Elite DPS: &2$EDPS", true);

--- a/src/main/java/com/magmaguy/elitemobs/dungeons/EMPackage.java
+++ b/src/main/java/com/magmaguy/elitemobs/dungeons/EMPackage.java
@@ -3,6 +3,7 @@ package com.magmaguy.elitemobs.dungeons;
 import com.magmaguy.elitemobs.MetadataHandler;
 import com.magmaguy.elitemobs.config.DungeonsConfig;
 import com.magmaguy.elitemobs.config.InitializeConfig;
+import com.magmaguy.elitemobs.config.ItemSettingsConfig;
 import com.magmaguy.elitemobs.config.contentpackages.ContentPackagesConfigFields;
 import com.magmaguy.elitemobs.menus.SetupMenuIcons;
 import com.magmaguy.elitemobs.mobconstructor.custombosses.CustomBossEntity;
@@ -198,7 +199,8 @@ public abstract class EMPackage extends ContentPackage {
                 tooltip);
         ItemMeta itemMeta = itemStack.getItemMeta();
         itemMeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-        itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+        if (ItemSettingsConfig.isHideEnchants())
+            itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         itemMeta.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
         itemStack.setItemMeta(itemMeta);
         SetupMenuIcons.applyItemModel(itemStack, SetupMenuIcons.MODEL_LOCKED_UNPAID);
@@ -241,7 +243,8 @@ public abstract class EMPackage extends ContentPackage {
                 tooltip);
         ItemMeta itemMeta = itemStack.getItemMeta();
         itemMeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-        itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+        if (ItemSettingsConfig.isHideEnchants())
+            itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         itemMeta.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
         itemStack.setItemMeta(itemMeta);
         SetupMenuIcons.applyItemModel(itemStack, SetupMenuIcons.MODEL_UPDATE_UNPAID);
@@ -254,7 +257,8 @@ public abstract class EMPackage extends ContentPackage {
         ItemStack itemStack = ItemStackGenerator.generateItemStack(material, contentPackagesConfigFields.getName(), tooltip);
         ItemMeta itemMeta = itemStack.getItemMeta();
         itemMeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-        itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+        if (ItemSettingsConfig.isHideEnchants())
+            itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         itemMeta.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
         itemStack.setItemMeta(itemMeta);
         return itemStack;
@@ -270,7 +274,8 @@ public abstract class EMPackage extends ContentPackage {
                 tooltip);
         ItemMeta itemMeta = itemStack.getItemMeta();
         itemMeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-        itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+        if (ItemSettingsConfig.isHideEnchants())
+            itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         itemMeta.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
         itemStack.setItemMeta(itemMeta);
         SetupMenuIcons.applyItemModel(itemStack, modelId);

--- a/src/main/java/com/magmaguy/elitemobs/items/itemconstructor/ItemConstructor.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/itemconstructor/ItemConstructor.java
@@ -9,6 +9,7 @@ import com.magmaguy.elitemobs.items.potioneffects.ElitePotionEffectContainer;
 import com.magmaguy.elitemobs.mobconstructor.EliteEntity;
 import com.magmaguy.elitemobs.utils.CustomModelAdder;
 import com.magmaguy.magmacore.util.ChatColorConverter;
+import com.magmaguy.elitemobs.config.ItemSettingsConfig;
 import com.magmaguy.magmacore.util.ItemStackGenerator;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -209,7 +210,8 @@ public class ItemConstructor {
         ItemMeta itemMeta = itemStack.getItemMeta();
 
         //hide default lore
-        itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+        if (ItemSettingsConfig.isHideEnchants())
+            itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
 
         /*
         Register elite item


### PR DESCRIPTION
**Why?**

- Many third-party plugins (e.g. EnchantsSquared, EcoEnchants, Nexo, Custom-made) extend or override Minecraft's enchantment tooltip system. When HIDE_ENCHANTS is applied unconditionally, these plugins cannot display their enchantment data on EliteMobs items, creating a silent conflict that is difficult to diagnose.

- Server administrators currently have no recourse, they must either disable enchantment-related features entirely or remove EliteMobs, both of which are disproportionate solutions to what should be a simple toggle.

- The Minecraft plugin ecosystem is evolving rapidly. Hardcoding display flags reduces EliteMobs' compatibility surface and makes it harder for servers to build enriched gameplay on top of it.

- This is a non-breaking quality-of-life gap: the feature works fine in isolation but blocks interoperability with a growing class of enchantment plugins.

**What I did?**

- Added a new boolean config option hideEnchants (default: true) in the item settings configuration file.
- Wrapped every ItemFlag.HIDE_ENCHANTS call in a guard that reads this config value at runtime.
- Defaulting to true ensures zero behaviour change for existing servers on upgrade, opt-out only.
- Servers that run third-party enchantment plugins can now set hideEnchants: false to allow those plugins to render enchantment tooltips on EliteMobs items normally.
- The change is minimal and surgical, no refactoring, no logic changes outside of the flag application sites.

Hope this will be added as a feature.